### PR TITLE
Fix HTTP status code to be Rack 3 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ class Server
         puts "Got #{message}"
       end
       tubesock.listen
-      [ -1, {}, [] ]
+      [101, {}, [] ]
     else
       [404, {'Content-Type' => 'text/plain'}, ['Not Found']]
     end

--- a/lib/tubesock/hijack.rb
+++ b/lib/tubesock/hijack.rb
@@ -33,7 +33,7 @@ module Tubesock::Hijack
         ActiveRecord::Base.clear_active_connections! if defined? ActiveRecord
       end
       sock.listen
-      render plain: nil, status: -1
+      render plain: nil, status: 101
     end
   end
 end


### PR DESCRIPTION
Returning -1 is neither allowed by the HTTP standard nor by Rack.