### PR TITLE
Check for data presence in `each_frame`

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -102,7 +102,7 @@ class Tubesock
 
     @active = false
   end
-  
+
   def close!
     if @socket.respond_to?(:closed?)
       @socket.close unless @socket.closed?
@@ -142,7 +142,7 @@ class Tubesock
       else
         data, _addrinfo = @socket.readpartial(2000), @socket.peeraddr
       end
-      break if data.empty?
+      break if data.nil? || data.empty?
       framebuffer << data
       while frame = framebuffer.next
         case frame.type


### PR DESCRIPTION
This is an actual bug we observe regularly. It causes further issues and abnormal thread / Puma worker termination.