### PR TITLE
Use current Rails methods to clear active connections

### DIFF
--- a/lib/tubesock/hijack.rb
+++ b/lib/tubesock/hijack.rb
@@ -30,7 +30,7 @@ module Tubesock::Hijack
       sock = Tubesock.hijack(request.env)
       yield sock
       sock.onclose do
-        ActiveRecord::Base.clear_active_connections! if defined? ActiveRecord
+        ActiveRecord::Base.connection_handler.clear_active_connections! if defined? ActiveRecord
       end
       sock.listen
       render plain: nil, status: -1


### PR DESCRIPTION
This change is based on the code extracted from https://github.com/openHPI/codeocean/pull/2580.
